### PR TITLE
✈️ Add Flights Results Page with Data Formatting and Mock Integration

### DIFF
--- a/travel-planner/CHANGELOG.md
+++ b/travel-planner/CHANGELOG.md
@@ -40,3 +40,10 @@ All notable changes to this project will be documented in this file.
 
 - Created Flights Results Page displaying mock flight data
 - Introduced mock data file for layout testing and design iteration
+
+## [0.6.0] - 2025-10-07
+
+### Added
+
+- Helper functions for formatting dates, stops, and cabin class with baggage
+- FlightOffers TypeScript interface for flight data

--- a/travel-planner/CHANGELOG.md
+++ b/travel-planner/CHANGELOG.md
@@ -33,3 +33,10 @@ All notable changes to this project will be documented in this file.
 - Integrated React Router DOM for app-wide navigation
 - Created reusable, accessible Button component
 - Improved project structure organization for scalability
+
+## [0.5.0] - 2025-10-06
+
+### Added
+
+- Created Flights Results Page displaying mock flight data
+- Introduced mock data file for layout testing and design iteration

--- a/travel-planner/CHANGELOG.md
+++ b/travel-planner/CHANGELOG.md
@@ -47,3 +47,12 @@ All notable changes to this project will be documented in this file.
 
 - Helper functions for formatting dates, stops, and cabin class with baggage
 - FlightOffers TypeScript interface for flight data
+
+## [0.7.0] - 2025-10-07
+
+### Added
+
+- Mock JSON file with sample flight offers to test Flights Results Page
+- Integrated FlightCard component with data fetched from mock JSON file
+- Implemented loading and error handling for Flights Results Page
+- Established structure for future API-based data fetching

--- a/travel-planner/README.md
+++ b/travel-planner/README.md
@@ -96,6 +96,25 @@ Example route structure:
 
 A reusable Button component was added to maintain consistent styling and behavior across the app.
 
+## Flights Results Page
+
+The **Flights Results Page** displays available flight options based on user input.  
+Currently, it uses **mock data** to simulate results until the Amadeus API integration is complete.
+
+### 🧩 Features
+
+- Responsive list/grid layout for flight results
+- Displays mock flight details such as:
+  - Airline name and logo
+  - Departure and arrival times
+  - Flight duration
+  - Cabin class and price
+
+### Data
+
+For now, the data is static and located in a mock data file within the project.  
+This setup allows for easy testing of the layout and styling before connecting to the live API.
+
 ## Getting Started
 
 ### Prerequisites

--- a/travel-planner/README.md
+++ b/travel-planner/README.md
@@ -142,6 +142,44 @@ Voyant now includes **helper functions** and **data interfaces** to streamline f
   console.log(getCabinClassAndBaggage(flight.cabin, flight.bags));
   ```
 
+## Flights Results Integration
+
+The **Flights Results Page** now dynamically fetches data from a local mock JSON file (`/flightoffers.json`) and renders it using the **FlightCard** component.
+
+### Implementation Overview
+
+- **Mock JSON file**: Contains sample flight offers to test UI and layout before API integration.
+
+- **Data Fetching**
+
+  - Uses `fetch()` inside a `useEffect()` hook to retrieve mock flight data.
+  - Handles loading and error states gracefully.
+  - Updates component state (`flights`, `loading`, `error`) accordingly.
+
+- **Component Integration**
+  - Each flight result is displayed through a reusable **FlightCard** component.
+  - `FlightCard` presents flight details such as airline, departure/arrival, stops, duration, and price.
+
+### Example Code
+
+```tsx
+useEffect(() => {
+  const fetchFlights = async () => {
+    try {
+      const response = await fetch("/flightoffers.json");
+      if (!response.ok) throw new Error("Failed to fetch flight data");
+      const data = await response.json();
+      setFlights(data.data);
+      setLoading(false);
+    } catch (err) {
+      setError((err as Error).message);
+      setLoading(false);
+    }
+  };
+  fetchFlights();
+}, []);
+```
+
 ## Getting Started
 
 ### Prerequisites

--- a/travel-planner/README.md
+++ b/travel-planner/README.md
@@ -101,7 +101,7 @@ A reusable Button component was added to maintain consistent styling and behavio
 The **Flights Results Page** displays available flight options based on user input.  
 Currently, it uses **mock data** to simulate results until the Amadeus API integration is complete.
 
-### 🧩 Features
+### Features
 
 - Responsive list/grid layout for flight results
 - Displays mock flight details such as:
@@ -114,6 +114,33 @@ Currently, it uses **mock data** to simulate results until the Amadeus API integ
 
 For now, the data is static and located in a mock data file within the project.  
 This setup allows for easy testing of the layout and styling before connecting to the live API.
+
+## Utility Functions & Data Structures
+
+Voyant now includes **helper functions** and **data interfaces** to streamline flight data handling:
+
+### Helper Functions
+
+- `formatDate(isoString: string): string`
+- `formatStops(segments: Segment[]): string`
+- `getCabinClassAndBaggage(flight: flightOffer):{cabin: string;bags: string;}: string`
+
+### Flight Data Structures
+
+- **FlightOffers interface**: Defines the structure of flight offer objects.
+
+  Example usage:
+
+  ```ts
+  const flight: FlightOffer = mockData[0];
+
+  console.log(formatDate(flight.itineraries[0].segments[
+                      flight.itineraries[0].segments.length - 1
+                    ].arrival.at
+                  ).date));
+  console.log(formatStops(flight.itineraries[0].segments));
+  console.log(getCabinClassAndBaggage(flight.cabin, flight.bags));
+  ```
 
 ## Getting Started
 

--- a/travel-planner/public/flightoffers.json
+++ b/travel-planner/public/flightoffers.json
@@ -1,0 +1,513 @@
+{
+  "meta": {
+    "count": 2,
+    "links": {
+      "self": "https://test.api.amadeus.com/v2/shopping/flight-offers?originLocationCode=SYD&destinationLocationCode=BKK&departureDate=2021-11-01&adults=1&max=2"
+    }
+  },
+  "data": [
+    {
+      "type": "flight-offer",
+      "id": "1",
+      "source": "GDS",
+      "instantTicketingRequired": false,
+      "nonHomogeneous": false,
+      "oneWay": false,
+      "lastTicketingDate": "2021-11-01",
+      "numberOfBookableSeats": 9,
+      "itineraries": [
+        {
+          "duration": "PT14H15M",
+          "segments": [
+            {
+              "departure": {
+                "iataCode": "SYD",
+                "terminal": "1",
+                "at": "2021-11-01T11:35:00"
+              },
+              "arrival": {
+                "iataCode": "MNL",
+                "terminal": "2",
+                "at": "2021-11-01T16:50:00"
+              },
+              "carrierCode": "PR",
+              "number": "212",
+              "aircraft": {
+                "code": "333"
+              },
+              "operating": {
+                "carrierCode": "PR"
+              },
+              "duration": "PT8H15M",
+              "id": "1",
+              "numberOfStops": 0,
+              "blacklistedInEU": false
+            },
+            {
+              "departure": {
+                "iataCode": "MNL",
+                "terminal": "1",
+                "at": "2021-11-01T19:20:00"
+              },
+              "arrival": {
+                "iataCode": "BKK",
+                "at": "2021-11-01T21:50:00"
+              },
+              "carrierCode": "PR",
+              "number": "732",
+              "aircraft": {
+                "code": "320"
+              },
+              "operating": {
+                "carrierCode": "PR"
+              },
+              "duration": "PT3H30M",
+              "id": "2",
+              "numberOfStops": 0,
+              "blacklistedInEU": false
+            }
+          ]
+        }
+      ],
+      "price": {
+        "currency": "EUR",
+        "total": "355.34",
+        "base": "255.00",
+        "fees": [
+          {
+            "amount": "0.00",
+            "type": "SUPPLIER"
+          },
+          {
+            "amount": "0.00",
+            "type": "TICKETING"
+          }
+        ],
+        "grandTotal": "355.34"
+      },
+      "pricingOptions": {
+        "fareType": ["PUBLISHED"],
+        "includedCheckedBagsOnly": true
+      },
+      "validatingAirlineCodes": ["PR"],
+      "travelerPricings": [
+        {
+          "travelerId": "1",
+          "fareOption": "STANDARD",
+          "travelerType": "ADULT",
+          "price": {
+            "currency": "EUR",
+            "total": "355.34",
+            "base": "255.00"
+          },
+          "fareDetailsBySegment": [
+            {
+              "segmentId": "1",
+              "cabin": "ECONOMY",
+              "fareBasis": "EOBAU",
+              "class": "E",
+              "includedCheckedBags": {
+                "weight": 25,
+                "weightUnit": "KG"
+              }
+            },
+            {
+              "segmentId": "2",
+              "cabin": "ECONOMY",
+              "fareBasis": "EOBAU",
+              "class": "E",
+              "includedCheckedBags": {
+                "weight": 25,
+                "weightUnit": "KG"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "flight-offer",
+      "id": "2",
+      "source": "GDS",
+      "instantTicketingRequired": false,
+      "nonHomogeneous": false,
+      "oneWay": false,
+      "lastTicketingDate": "2021-11-01",
+      "numberOfBookableSeats": 9,
+      "itineraries": [
+        {
+          "duration": "PT16H35M",
+          "segments": [
+            {
+              "departure": {
+                "iataCode": "SYD",
+                "terminal": "1",
+                "at": "2021-11-01T11:35:00"
+              },
+              "arrival": {
+                "iataCode": "MNL",
+                "terminal": "2",
+                "at": "2021-11-01T16:50:00"
+              },
+              "carrierCode": "PR",
+              "number": "212",
+              "aircraft": {
+                "code": "333"
+              },
+              "operating": {
+                "carrierCode": "PR"
+              },
+              "duration": "PT8H15M",
+              "id": "3",
+              "numberOfStops": 0,
+              "blacklistedInEU": false
+            },
+            {
+              "departure": {
+                "iataCode": "MNL",
+                "terminal": "1",
+                "at": "2021-11-01T21:40:00"
+              },
+              "arrival": {
+                "iataCode": "BKK",
+                "at": "2021-11-02T00:10:00"
+              },
+              "carrierCode": "PR",
+              "number": "740",
+              "aircraft": {
+                "code": "321"
+              },
+              "operating": {
+                "carrierCode": "PR"
+              },
+              "duration": "PT3H30M",
+              "id": "4",
+              "numberOfStops": 0,
+              "blacklistedInEU": false
+            }
+          ]
+        }
+      ],
+      "price": {
+        "currency": "EUR",
+        "total": "355.34",
+        "base": "255.00",
+        "fees": [
+          {
+            "amount": "0.00",
+            "type": "SUPPLIER"
+          },
+          {
+            "amount": "0.00",
+            "type": "TICKETING"
+          }
+        ],
+        "grandTotal": "355.34"
+      },
+      "pricingOptions": {
+        "fareType": ["PUBLISHED"],
+        "includedCheckedBagsOnly": true
+      },
+      "validatingAirlineCodes": ["PR"],
+      "travelerPricings": [
+        {
+          "travelerId": "1",
+          "fareOption": "STANDARD",
+          "travelerType": "ADULT",
+          "price": {
+            "currency": "EUR",
+            "total": "355.34",
+            "base": "255.00"
+          },
+          "fareDetailsBySegment": [
+            {
+              "segmentId": "3",
+              "cabin": "ECONOMY",
+              "fareBasis": "EOBAU",
+              "class": "E",
+              "includedCheckedBags": {
+                "weight": 25,
+                "weightUnit": "KG"
+              }
+            },
+            {
+              "segmentId": "4",
+              "cabin": "ECONOMY",
+              "fareBasis": "EOBAU",
+              "class": "E",
+              "includedCheckedBags": {
+                "weight": 25,
+                "weightUnit": "KG"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "flight-offer",
+      "id": "3",
+      "source": "GDS",
+      "instantTicketingRequired": false,
+      "nonHomogeneous": false,
+      "oneWay": false,
+      "lastTicketingDate": "2021-11-01",
+      "numberOfBookableSeats": 9,
+      "itineraries": [
+        {
+          "duration": "PT16H35M",
+          "segments": [
+            {
+              "departure": {
+                "iataCode": "SYD",
+                "terminal": "1",
+                "at": "2021-11-01T11:35:00"
+              },
+              "arrival": {
+                "iataCode": "MNL",
+                "terminal": "2",
+                "at": "2021-11-01T16:50:00"
+              },
+              "carrierCode": "PR",
+              "number": "212",
+              "aircraft": {
+                "code": "333"
+              },
+              "operating": {
+                "carrierCode": "PR"
+              },
+              "duration": "PT8H15M",
+              "id": "5",
+              "numberOfStops": 0,
+              "blacklistedInEU": false
+            },
+            {
+              "departure": {
+                "iataCode": "MNL",
+                "terminal": "1",
+                "at": "2021-11-01T21:40:00"
+              },
+              "arrival": {
+                "iataCode": "BKK",
+                "at": "2021-11-02T00:10:00"
+              },
+              "carrierCode": "PR",
+              "number": "740",
+              "aircraft": {
+                "code": "321"
+              },
+              "operating": {
+                "carrierCode": "PR"
+              },
+              "duration": "PT3H30M",
+              "id": "6",
+              "numberOfStops": 0,
+              "blacklistedInEU": false
+            }
+          ]
+        }
+      ],
+      "price": {
+        "currency": "EUR",
+        "total": "355.34",
+        "base": "255.00",
+        "fees": [
+          {
+            "amount": "0.00",
+            "type": "SUPPLIER"
+          },
+          {
+            "amount": "0.00",
+            "type": "TICKETING"
+          }
+        ],
+        "grandTotal": "355.34"
+      },
+      "pricingOptions": {
+        "fareType": ["PUBLISHED"],
+        "includedCheckedBagsOnly": true
+      },
+      "validatingAirlineCodes": ["PR"],
+      "travelerPricings": [
+        {
+          "travelerId": "1",
+          "fareOption": "STANDARD",
+          "travelerType": "ADULT",
+          "price": {
+            "currency": "EUR",
+            "total": "355.34",
+            "base": "255.00"
+          },
+          "fareDetailsBySegment": [
+            {
+              "segmentId": "5",
+              "cabin": "ECONOMY",
+              "fareBasis": "EOBAU",
+              "class": "E",
+              "includedCheckedBags": {
+                "weight": 25,
+                "weightUnit": "KG"
+              }
+            },
+            {
+              "segmentId": "6",
+              "cabin": "ECONOMY",
+              "fareBasis": "EOBAU",
+              "class": "E",
+              "includedCheckedBags": {
+                "weight": 25,
+                "weightUnit": "KG"
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "flight-offer",
+      "id": "4",
+      "source": "GDS",
+      "instantTicketingRequired": false,
+      "nonHomogeneous": false,
+      "oneWay": false,
+      "lastTicketingDate": "2021-11-01",
+      "numberOfBookableSeats": 9,
+      "itineraries": [
+        {
+          "duration": "PT16H35M",
+          "segments": [
+            {
+              "departure": {
+                "iataCode": "SYD",
+                "terminal": "1",
+                "at": "2021-11-01T11:35:00"
+              },
+              "arrival": {
+                "iataCode": "MNL",
+                "terminal": "2",
+                "at": "2021-11-01T16:50:00"
+              },
+              "carrierCode": "PR",
+              "number": "212",
+              "aircraft": {
+                "code": "333"
+              },
+              "operating": {
+                "carrierCode": "PR"
+              },
+              "duration": "PT8H15M",
+              "id": "7",
+              "numberOfStops": 0,
+              "blacklistedInEU": false
+            },
+            {
+              "departure": {
+                "iataCode": "MNL",
+                "terminal": "1",
+                "at": "2021-11-01T21:40:00"
+              },
+              "arrival": {
+                "iataCode": "BKK",
+                "at": "2021-11-02T00:10:00"
+              },
+              "carrierCode": "PR",
+              "number": "740",
+              "aircraft": {
+                "code": "321"
+              },
+              "operating": {
+                "carrierCode": "PR"
+              },
+              "duration": "PT3H30M",
+              "id": "8",
+              "numberOfStops": 0,
+              "blacklistedInEU": false
+            }
+          ]
+        }
+      ],
+      "price": {
+        "currency": "EUR",
+        "total": "355.34",
+        "base": "255.00",
+        "fees": [
+          {
+            "amount": "0.00",
+            "type": "SUPPLIER"
+          },
+          {
+            "amount": "0.00",
+            "type": "TICKETING"
+          }
+        ],
+        "grandTotal": "355.34"
+      },
+      "pricingOptions": {
+        "fareType": ["PUBLISHED"],
+        "includedCheckedBagsOnly": true
+      },
+      "validatingAirlineCodes": ["PR"],
+      "travelerPricings": [
+        {
+          "travelerId": "1",
+          "fareOption": "STANDARD",
+          "travelerType": "ADULT",
+          "price": {
+            "currency": "EUR",
+            "total": "355.34",
+            "base": "255.00"
+          },
+          "fareDetailsBySegment": [
+            {
+              "segmentId": "7",
+              "cabin": "ECONOMY",
+              "fareBasis": "EOBAU",
+              "class": "E",
+              "includedCheckedBags": {
+                "weight": 25,
+                "weightUnit": "KG"
+              }
+            },
+            {
+              "segmentId": "8",
+              "cabin": "ECONOMY",
+              "fareBasis": "EOBAU",
+              "class": "E",
+              "includedCheckedBags": {
+                "weight": 25,
+                "weightUnit": "KG"
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "dictionaries": {
+    "locations": {
+      "BKK": {
+        "cityCode": "BKK",
+        "countryCode": "TH"
+      },
+      "MNL": {
+        "cityCode": "MNL",
+        "countryCode": "PH"
+      },
+      "SYD": {
+        "cityCode": "SYD",
+        "countryCode": "AU"
+      }
+    },
+    "aircraft": {
+      "320": "AIRBUS A320",
+      "321": "AIRBUS A321",
+      "333": "AIRBUS A330-300"
+    },
+    "currencies": {
+      "EUR": "EURO"
+    },
+    "carriers": {
+      "PR": "PHILIPPINE AIRLINES"
+    }
+  }
+}

--- a/travel-planner/src/components/common/FlightCard.tsx
+++ b/travel-planner/src/components/common/FlightCard.tsx
@@ -1,0 +1,104 @@
+import type { FlightOffer } from "../../interfaces/FlightOffer";
+import { formatDateTime } from "../../utils/formatDate";
+import { formatStops } from "../../utils/formatStops";
+import { getCabinAndBags } from "../../utils/getCabinAndBags";
+import flightLogo from "../../assets/images/flights/flight2.jpg";
+
+export default function FlightCard(flight: FlightOffer) {
+  return (
+    <div className="p-4 border border-[var(--color-border)] rounded-2xl bg-gradient-to-br from-slate-100 via-sky-50 to-sky-200 dark:from-slate-800 dark:via-slate-700 dark:to-slate-600 shadow-md hover:shadow-lg transition-all duration-200 backdrop-blur-md">
+      <p className="text-right italic text-xs text-red-400">
+        Only {flight.numberOfBookableSeats} seats left at this price!!!
+      </p>
+
+      {/* Flight summary */}
+      <div className="my-3 flex justify-between text-sm">
+        <div className="flex gap-2 items-center">
+          <img
+            src={flightLogo}
+            alt="logo"
+            className="w-7 h-7 rounded-full bg-rose-100 object-cover"
+          />
+          <p className="font-bold">
+            {flight.validatingAirlineCodes.join(", ")}{" "}
+          </p>
+        </div>
+        <p>
+          <span className="font-semibold">
+            {flight.itineraries[0].duration.replace("PT", "").toLowerCase()}
+          </span>{" "}
+          <span className="text-[var(--color-text-secondary)]">
+            ({formatStops(flight.itineraries[0].segments)})
+          </span>
+        </p>
+      </div>
+
+      {/* Flight details */}
+      <div className="min-[480px]:flex justify-between gap-12 text-sm p-3 border-t border-[var(--color-border)]">
+        <div className="flex gap-2 items-center w-full max-w-md">
+          {/* Origin */}
+          <div className="flex flex-col items-center">
+            <span className="font-bold">
+              {flight.itineraries[0].segments[0].departure.iataCode}
+            </span>
+            <span>
+              {
+                formatDateTime(flight.itineraries[0].segments[0].departure.at)
+                  .date
+              }
+            </span>
+            <span className="font-semibold">
+              {
+                formatDateTime(flight.itineraries[0].segments[0].departure.at)
+                  .time
+              }
+            </span>
+          </div>
+
+          <div className="flex-1 border-t border-dashed border-[var(--color-placeholder)] mx-2"></div>
+
+          {/* Destination */}
+          <div className="flex flex-col items-center">
+            <span className="font-bold">
+              {
+                flight.itineraries[0].segments[
+                  flight.itineraries[0].segments.length - 1
+                ].arrival.iataCode
+              }
+            </span>
+            <span>
+              {
+                formatDateTime(
+                  flight.itineraries[0].segments[
+                    flight.itineraries[0].segments.length - 1
+                  ].arrival.at
+                ).date
+              }
+            </span>
+            <span className="font-semibold">
+              {
+                formatDateTime(
+                  flight.itineraries[0].segments[
+                    flight.itineraries[0].segments.length - 1
+                  ].arrival.at
+                ).time
+              }
+            </span>
+          </div>
+        </div>
+
+        {/* Price info */}
+        <div className="flex justify-evenly min-[480px]:flex-col min-[480px]:justify-center items-center text-[var(--color-text-secondary)]">
+          <span className="text-xl font-bold text-[var(--color-accent)]">
+            {flight.price.currency}
+            {flight.price.total}
+          </span>
+          <span className="text-xs font-medium">
+            {getCabinAndBags(flight).cabin}
+          </span>
+          <span>{getCabinAndBags(flight).bags}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/travel-planner/src/interfaces/FlightOffer.ts
+++ b/travel-planner/src/interfaces/FlightOffer.ts
@@ -1,0 +1,116 @@
+// src/types/FlightOffer.ts
+
+export interface FlightOfferResponse {
+  meta: {
+    count: number;
+    links: {
+      self: string;
+    };
+  };
+  data: FlightOffer[];
+  dictionaries: Dictionaries;
+}
+
+export interface FlightOffer {
+  type: string;
+  id: string;
+  source: string;
+  instantTicketingRequired: boolean;
+  nonHomogeneous: boolean;
+  oneWay: boolean;
+  lastTicketingDate: string;
+  numberOfBookableSeats: number;
+  itineraries: Itinerary[];
+  price: Price;
+  pricingOptions: PricingOptions;
+  validatingAirlineCodes: string[];
+  travelerPricings: TravelerPricing[];
+}
+
+export interface Itinerary {
+  duration: string; // Example: "PT14H15M"
+  segments: Segment[];
+}
+
+export interface Segment {
+  departure: FlightEndpoint;
+  arrival: FlightEndpoint;
+  carrierCode: string;
+  number: string;
+  aircraft: Aircraft;
+  operating: Operating;
+  duration: string;
+  id: string;
+  numberOfStops: number;
+  blacklistedInEU: boolean;
+}
+
+export interface FlightEndpoint {
+  iataCode: string;
+  terminal?: string;
+  at: string; // ISO Date string
+}
+
+export interface Aircraft {
+  code: string;
+}
+
+export interface Operating {
+  carrierCode: string;
+}
+
+export interface Price {
+  currency: string;
+  total: string;
+  base: string;
+  fees: Fee[];
+  grandTotal: string;
+}
+
+export interface Fee {
+  amount: string;
+  type: string;
+}
+
+export interface PricingOptions {
+  fareType: string[];
+  includedCheckedBagsOnly: boolean;
+}
+
+export interface TravelerPricing {
+  travelerId: string;
+  fareOption: string;
+  travelerType: string;
+  price: TravelerPrice;
+  fareDetailsBySegment: FareDetailsBySegment[];
+}
+
+export interface TravelerPrice {
+  currency: string;
+  total: string;
+  base: string;
+}
+
+export interface FareDetailsBySegment {
+  segmentId: string;
+  cabin: string;
+  fareBasis: string;
+  class: string;
+  includedCheckedBags: {
+    weight: number;
+    weightUnit: string;
+  };
+}
+
+export interface Dictionaries {
+  locations: Record<
+    string,
+    {
+      cityCode: string;
+      countryCode: string;
+    }
+  >;
+  aircraft: Record<string, string>;
+  currencies: Record<string, string>;
+  carriers: Record<string, string>;
+}

--- a/travel-planner/src/pages/Flights/results.tsx
+++ b/travel-planner/src/pages/Flights/results.tsx
@@ -1,3 +1,183 @@
+import { FaArrowsLeftRight } from "react-icons/fa6";
+import Tabs from "../../components/Tabs";
+import Button from "../../components/common/Button";
+import flightHero from "../../assets/images/flights/passport.jpg";
+import flightLogo from "../../assets/images/flights/flight2.jpg";
+
 export default function FlightsResults() {
-  return <div className="container p-6">Flights Results</div>;
+  const flights = [
+    {
+      id: 1,
+      airline: "Emirates",
+      departure: "HRE",
+      arrival: "DXB",
+      duration: "8h 25m",
+      price: "$650",
+    },
+    {
+      id: 2,
+      airline: "Qatar Airways",
+      departure: "HRE",
+      arrival: "DXB",
+      duration: "8h 45m",
+      price: "$620",
+    },
+    {
+      id: 3,
+      airline: "Ethiopian Airlines",
+      departure: "HRE",
+      arrival: "DXB",
+      duration: "7h 15m",
+      price: "$580",
+    },
+    {
+      id: 4,
+      airline: "Turkish Airlines",
+      departure: "HRE",
+      arrival: "DXB",
+      duration: "9h 05m",
+      price: "$600",
+    },
+    {
+      id: 5,
+      airline: "KLM",
+      departure: "HRE",
+      arrival: "DXB",
+      duration: "8h 30m",
+      price: "$640",
+    },
+    {
+      id: 6,
+      airline: "Lufthansa",
+      departure: "HRE",
+      arrival: "DXB",
+      duration: "8h 50m",
+      price: "$630",
+    },
+  ];
+
+  return (
+    <div className="container mx-auto p-6">
+      {/* Tabs */}
+      <Tabs />
+
+      <div
+        className="relative flex flex-col justify-center items-center my-10 rounded-3xl shadow-lg p-6 text-center text-[var(--color-text-primary)] overflow-hidden bg-cover bg-center bg-no-repeat w-full max-w-5xl h-60 md:h-70 lg:h-80 mx-auto"
+        style={{ backgroundImage: `url(${flightHero})` }}
+      >
+        {/* Dark overlay */}
+        <div className="absolute inset-0 bg-black/60 rounded-3xl"></div>
+
+        {/* Content */}
+        <div className="relative z-10">
+          <h2 className="text-3xl font-semibold text-white">
+            Your Journey Begins Here
+          </h2>
+          <p className="max-w-2xl mx-auto mt-3 text-gray-200">
+            Our platform connects you to top airlines and exclusive deals
+            tailored to your preferences. Experience effortless booking,
+            transparent pricing, and curated recommendations to make every trip
+            as smooth as takeoff.
+          </p>
+        </div>
+      </div>
+
+      {/* Modify Search */}
+      <div className="flex flex-col items-center text-lg mb-6">
+        <div className="flex justify-center items-center gap-4">
+          <span className="font-semibold">HRE</span>
+          <FaArrowsLeftRight
+            className="text-[var(--color-placeholder)]"
+            aria-label="Direction"
+          />
+          <span className="font-semibold">DXB</span>
+        </div>
+        <button
+          type="button"
+          aria-label="Modify Search"
+          className="text-[var(--color-accent)] font-semibold underline underline-offset-2 hover:opacity-80 focus:ring-0 bg-transparent mt-2"
+          onClick={() => {}}
+        >
+          Modify Search
+        </button>
+      </div>
+
+      {/* Flight Cards */}
+      <div className="my-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {flights.map((flight) => (
+          <div
+            key={flight.id}
+            className="p-4 border border-[var(--color-border)] rounded-2xl bg-gradient-to-br from-slate-100 via-sky-50 to-sky-200 dark:from-slate-800 dark:via-slate-700 dark:to-slate-600 shadow-md hover:shadow-lg transition-all duration-200 backdrop-blur-md"
+          >
+            <p className="text-right italic text-xs text-red-400">
+              Only 9 seats left at this price!!!
+            </p>
+
+            {/* Flight summary */}
+            <div className="my-3 flex justify-between text-sm">
+              <div className="flex gap-2 items-center">
+                <img
+                  src={flightLogo}
+                  alt={`${flight.airline} logo`}
+                  className="w-7 h-7 rounded-full bg-rose-100 object-cover"
+                />
+                <p className="font-bold">{flight.airline}</p>
+              </div>
+              <p>
+                <span className="font-semibold">{flight.duration}</span>{" "}
+                <span className="text-[var(--color-text-secondary)]">
+                  (1 stop)
+                </span>
+              </p>
+            </div>
+
+            {/* Flight details */}
+            <div className="flex justify-between gap-12 text-sm p-3 border-t border-[var(--color-border)]">
+              <div className="flex gap-2 items-center w-full max-w-md">
+                {/* Origin */}
+                <div className="flex flex-col items-center">
+                  <span className="font-bold">{flight.departure}</span>
+                  <span>Nov 11</span>
+                  <span className="font-semibold">11:35</span>
+                </div>
+
+                <div className="flex-1 border-t border-dashed border-[var(--color-placeholder)] mx-2"></div>
+
+                {/* Destination */}
+                <div className="flex flex-col items-center">
+                  <span className="font-bold">{flight.arrival}</span>
+                  <span>Nov 12</span>
+                  <span className="font-semibold">05:50</span>
+                </div>
+              </div>
+
+              {/* Price info */}
+              <div className="flex flex-col justify-center items-center text-[var(--color-text-secondary)]">
+                <span className="text-xl font-bold text-[var(--color-accent)]">
+                  {flight.price}
+                </span>
+                <span className="font-bold">Economy</span>
+                <span>25kg</span>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Show More */}
+      <Button
+        label="Show More"
+        className="mt-20 block mx-auto text-[var(--color-accent)] border-2 border-[var(--color-accent)] hover:bg-[var(--color-accent)] hover:text-white"
+      />
+
+      {/* Disclaimer */}
+      <p className="flex gap-2 text-sm text-[var(--color-text-secondary)] m-8 max-w-2xl mx-auto text-center">
+        <span>*</span>
+        <span>
+          Displayed fares include taxes and fees. Availability is subject to
+          change until your booking is completed.
+        </span>
+      </p>
+    </div>
+  );
 }

--- a/travel-planner/src/pages/Flights/results.tsx
+++ b/travel-planner/src/pages/Flights/results.tsx
@@ -2,65 +2,40 @@ import { FaArrowsLeftRight } from "react-icons/fa6";
 import Tabs from "../../components/Tabs";
 import Button from "../../components/common/Button";
 import flightHero from "../../assets/images/flights/passport.jpg";
-import flightLogo from "../../assets/images/flights/flight2.jpg";
+import { useEffect, useState } from "react";
+import type { FlightOffer } from "../../interfaces/FlightOffer";
+import FlightCard from "../../components/common/FlightCard";
 
 export default function FlightsResults() {
-  const flights = [
-    {
-      id: 1,
-      airline: "Emirates",
-      departure: "HRE",
-      arrival: "DXB",
-      duration: "8h 25m",
-      price: "$650",
-    },
-    {
-      id: 2,
-      airline: "Qatar Airways",
-      departure: "HRE",
-      arrival: "DXB",
-      duration: "8h 45m",
-      price: "$620",
-    },
-    {
-      id: 3,
-      airline: "Ethiopian Airlines",
-      departure: "HRE",
-      arrival: "DXB",
-      duration: "7h 15m",
-      price: "$580",
-    },
-    {
-      id: 4,
-      airline: "Turkish Airlines",
-      departure: "HRE",
-      arrival: "DXB",
-      duration: "9h 05m",
-      price: "$600",
-    },
-    {
-      id: 5,
-      airline: "KLM",
-      departure: "HRE",
-      arrival: "DXB",
-      duration: "8h 30m",
-      price: "$640",
-    },
-    {
-      id: 6,
-      airline: "Lufthansa",
-      departure: "HRE",
-      arrival: "DXB",
-      duration: "8h 50m",
-      price: "$630",
-    },
-  ];
+  const [flights, setFlights] = useState<FlightOffer[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch flight data from a local JSON file
+  useEffect(() => {
+    const fetchFlights = async () => {
+      try {
+        const response = await fetch("/flightoffers.json");
+        if (!response.ok) {
+          throw new Error("Failed to fetch flight data");
+        }
+        const data = await response.json();
+        setFlights(data.data);
+        setLoading(false);
+      } catch (err) {
+        setError((err as Error).message);
+        setLoading(false);
+      }
+    };
+    fetchFlights();
+  }, []);
 
   return (
     <div className="container mx-auto p-6">
       {/* Tabs */}
       <Tabs />
 
+      {/* Hero Section */}
       <div
         className="relative flex flex-col justify-center items-center my-10 rounded-3xl shadow-lg p-6 text-center text-[var(--color-text-primary)] overflow-hidden bg-cover bg-center bg-no-repeat w-full max-w-5xl h-60 md:h-70 lg:h-80 mx-auto"
         style={{ backgroundImage: `url(${flightHero})` }}
@@ -102,82 +77,45 @@ export default function FlightsResults() {
         </button>
       </div>
 
-      {/* Flight Cards */}
-      <div className="my-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
-        {flights.map((flight) => (
-          <div
-            key={flight.id}
-            className="p-4 border border-[var(--color-border)] rounded-2xl bg-gradient-to-br from-slate-100 via-sky-50 to-sky-200 dark:from-slate-800 dark:via-slate-700 dark:to-slate-600 shadow-md hover:shadow-lg transition-all duration-200 backdrop-blur-md"
-          >
-            <p className="text-right italic text-xs text-red-400">
-              Only 9 seats left at this price!!!
-            </p>
-
-            {/* Flight summary */}
-            <div className="my-3 flex justify-between text-sm">
-              <div className="flex gap-2 items-center">
-                <img
-                  src={flightLogo}
-                  alt={`${flight.airline} logo`}
-                  className="w-7 h-7 rounded-full bg-rose-100 object-cover"
-                />
-                <p className="font-bold">{flight.airline}</p>
-              </div>
-              <p>
-                <span className="font-semibold">{flight.duration}</span>{" "}
-                <span className="text-[var(--color-text-secondary)]">
-                  (1 stop)
-                </span>
-              </p>
-            </div>
-
-            {/* Flight details */}
-            <div className="flex justify-between gap-12 text-sm p-3 border-t border-[var(--color-border)]">
-              <div className="flex gap-2 items-center w-full max-w-md">
-                {/* Origin */}
-                <div className="flex flex-col items-center">
-                  <span className="font-bold">{flight.departure}</span>
-                  <span>Nov 11</span>
-                  <span className="font-semibold">11:35</span>
-                </div>
-
-                <div className="flex-1 border-t border-dashed border-[var(--color-placeholder)] mx-2"></div>
-
-                {/* Destination */}
-                <div className="flex flex-col items-center">
-                  <span className="font-bold">{flight.arrival}</span>
-                  <span>Nov 12</span>
-                  <span className="font-semibold">05:50</span>
-                </div>
-              </div>
-
-              {/* Price info */}
-              <div className="flex flex-col justify-center items-center text-[var(--color-text-secondary)]">
-                <span className="text-xl font-bold text-[var(--color-accent)]">
-                  {flight.price}
-                </span>
-                <span className="font-bold">Economy</span>
-                <span>25kg</span>
-              </div>
-            </div>
+      {loading ? (
+        <div className="container mx-auto p-6 text-center">
+          <p>Loading flight results...</p>
+        </div>
+      ) : error ? (
+        <div className="container mx-auto p-6 text-center text-red-500">
+          <p> Error: {error}</p>
+        </div>
+      ) : flights.length === 0 ? (
+        <div className="text-center">No flights found.</div>
+      ) : (
+        <>
+          {/* Flight Cards */}
+          <div className="my-10 grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+            {flights.map((flight) => (
+              <FlightCard key={flight.id} {...flight} />
+            ))}
           </div>
-        ))}
-      </div>
 
-      {/* Show More */}
-      <Button
-        label="Show More"
-        className="mt-20 block mx-auto text-[var(--color-accent)] border-2 border-[var(--color-accent)] hover:bg-[var(--color-accent)] hover:text-white"
-      />
+          {flights.length > 10 && (
+            <>
+              {/* Show More */}
+              <Button
+                label="Show More"
+                className="mt-20 block mx-auto text-[var(--color-accent)] border-2 border-[var(--color-accent)] hover:bg-[var(--color-accent)] hover:text-white"
+              />
+            </>
+          )}
 
-      {/* Disclaimer */}
-      <p className="flex gap-2 text-sm text-[var(--color-text-secondary)] m-8 max-w-2xl mx-auto text-center">
-        <span>*</span>
-        <span>
-          Displayed fares include taxes and fees. Availability is subject to
-          change until your booking is completed.
-        </span>
-      </p>
+          {/* Disclaimer */}
+          <p className="flex gap-2 text-sm text-[var(--color-text-secondary)] m-8 max-w-2xl mx-auto text-center">
+            <span>*</span>
+            <span>
+              Displayed fares include taxes and fees. Availability is subject to
+              change until your booking is completed.
+            </span>
+          </p>
+        </>
+      )}
     </div>
   );
 }

--- a/travel-planner/src/utils/formatDate.ts
+++ b/travel-planner/src/utils/formatDate.ts
@@ -1,0 +1,32 @@
+// src/utils/dateHelpers.ts
+
+/**
+ * Converts an ISO date string into separate formatted date and time.
+ * @example
+ * formatDateTime("2025-10-06T13:45:00")
+ * // { date: "Oct 06", time: "13:45" }
+ */
+export function formatDateTime(isoString: string): {
+  date: string;
+  time: string;
+} {
+  if (!isoString) return { date: "", time: "" };
+
+  const date = new Date(isoString);
+
+  const dateFormatter = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "2-digit",
+  });
+
+  const timeFormatter = new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+
+  return {
+    date: dateFormatter.format(date), // e.g. "Oct 06"
+    time: timeFormatter.format(date), // e.g. "13:45"
+  };
+}

--- a/travel-planner/src/utils/formatStops.ts
+++ b/travel-planner/src/utils/formatStops.ts
@@ -1,0 +1,19 @@
+import type { Segment } from "../interfaces/FlightOffer";
+
+/**
+ *
+ * @param segments Array of flight segments
+ * @returns Formatted string indicating number of stops, e.g. "1 stop" or "2 stops"
+ * Handles pluralization correctly.
+ * Examples:
+ * - 1 segment (non-stop): "non-stop"
+ * - 2 segments (1 stop): "1 stop"
+ * - 3 segments (2 stops): "2 stops"
+ * - 4 segments (3 stops): "3 stops"
+ * - etc.
+ */
+
+export function formatStops(segments: Segment[]): string {
+  const stops = segments.length - 1;
+  return stops === 0 ? "non-stop" : stops === 1 ? "1 stop" : `${stops} stops`;
+}

--- a/travel-planner/src/utils/getCabinAndBags.ts
+++ b/travel-planner/src/utils/getCabinAndBags.ts
@@ -1,0 +1,39 @@
+import type { FlightOffer } from "../interfaces/FlightOffer";
+
+/**
+ * Extracts cabin class and checked baggage info from a flight offer.
+ * Returns a consistent summary, e.g. { cabin: "Economy", bags: "25kg" }.
+ */
+export function getCabinAndBags(flight: FlightOffer): {
+  cabin: string;
+  bags: string;
+} {
+  if (
+    !flight.travelerPricings?.length ||
+    !flight.travelerPricings[0].fareDetailsBySegment?.length
+  ) {
+    return { cabin: "Unknown", bags: "N/A" };
+  }
+
+  const fareDetails = flight.travelerPricings[0].fareDetailsBySegment;
+
+  // Extract all cabins and weights
+  const cabins = fareDetails.map((seg) => seg.cabin);
+  const weights = fareDetails.map(
+    (seg) => seg.includedCheckedBags?.weight || 0
+  );
+
+  // Remove duplicate cabin classes
+  const uniqueCabins = [...new Set(cabins)];
+
+  // Pick max weight in case some legs differ
+  const maxWeight = Math.max(...weights);
+
+  // Format cabin display
+  const cabinDisplay = uniqueCabins.join(" / ");
+
+  return {
+    cabin: cabinDisplay,
+    bags: `${maxWeight}kg`,
+  };
+}


### PR DESCRIPTION
# Voyant
This pull request introduces the **Flights Results Page**, a key feature in the travel planner app that displays flight offers with enhanced UI and structured data presentation.

---

## **What’s New**

### [0.5.0] – 2025-10-06

- Created **Flights Results Page** displaying mock flight data
- Added **mock data file** for layout testing and design iteration

### [0.6.0] – 2025-10-07

- Added **helper functions** for formatting:

  - Dates (ISO → `MMM DD` + `HH:MM`)
  - Stops text (stop/stops)
  - Cabin class with checked baggage
- Introduced **TypeScript interfaces** for flight data consistency

### [0.7.0] – 2025-10-07

- Integrated **FlightCard component** to render data from mock JSON file
- Added **loading and error handling** to the Flights Results Page
- Established groundwork for **future API-based data fetching**

---

## How to Test

1. Run the app locally using `npm run dev`
2. Navigate to `/flights/results`
3. Confirm that:

   - Flight results load correctly from mock data
   - Dates, times, stops, and baggage info are properly formatted
   - Loading and error messages display correctly

---

## Next Steps

- Replace mock data with real API integration
- Add filters (price, duration, stops)
- Connect booking flow
